### PR TITLE
Adding README.md as this app has additional extensions to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ flatpak install flathub org.freedesktop.Platform.Compat.i386
 flatpak install flathub org.phoenicis.playonlinux
 ```
 
-## Run:
+## Run :
 ```
 flatpak run org.phoenicis.playonlinux
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+
+## Phoenicis PlayOnLinux
+
+Phoenicis PlayOnLinux is a graphical front-end for Wine.
+Install and run Windows software on Linux
+
+
+Command line instructions
+Install:
+Make sure to follow the setup guide before installing
+flatpak install flathub org.phoenicis.playonlinux
+Run:
+flatpak run org.phoenicis.playonlinux
+
+
+## Installation Instruction :
+
+Install Extension
+```
+flatpak install flathub org.freedesktop.Platform.Compat.i386
+```
+
+Install Application
+```
+flatpak install flathub org.phoenicis.playonlinux
+```
+
+## Run:
+```
+flatpak run org.phoenicis.playonlinux
+```

--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ flatpak install flathub org.phoenicis.playonlinux
 ```
 flatpak run org.phoenicis.playonlinux
 ```
+
+#### Website :
+
+https://flathub.org/apps/details/org.phoenicis.playonlinux
+
+
+#### Runtime/Sdk :
+```
+org.freedesktop.Platform/x86_64/18.08
+org.freedesktop.Sdk/x86_64/18.08
+```

--- a/README.md
+++ b/README.md
@@ -22,13 +22,7 @@ flatpak install flathub org.phoenicis.playonlinux
 flatpak run org.phoenicis.playonlinux
 ```
 
-#### Website :
+## Website :
 
 https://flathub.org/apps/details/org.phoenicis.playonlinux
 
-
-#### Runtime/Sdk :
-```
-org.freedesktop.Platform/x86_64/18.08
-org.freedesktop.Sdk/x86_64/18.08
-```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Phoenicis PlayOnLinux is a graphical front-end for Wine.
 Install and run Windows software on Linux
 
 
-## Installation Instruction :
+## Installation Instruction's :
 
 #### Install Extension
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Phoenicis PlayOnLinux is a graphical front-end for Wine.
 Install and run Windows software on Linux
 
 
-## Installation Instruction's :
+## Installation Instructions :
 
 #### Install Extension
 ```

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Install and run Windows software on Linux
 
 ## Installation Instruction :
 
-####Install Extension
+#### Install Extension
 ```
 flatpak install flathub org.freedesktop.Platform.Compat.i386
 ```
 
-####Install Application
+#### Install Application
 ```
 flatpak install flathub org.phoenicis.playonlinux
 ```

--- a/README.md
+++ b/README.md
@@ -5,22 +5,14 @@ Phoenicis PlayOnLinux is a graphical front-end for Wine.
 Install and run Windows software on Linux
 
 
-Command line instructions
-Install:
-Make sure to follow the setup guide before installing
-flatpak install flathub org.phoenicis.playonlinux
-Run:
-flatpak run org.phoenicis.playonlinux
-
-
 ## Installation Instruction :
 
-Install Extension
+####Install Extension
 ```
 flatpak install flathub org.freedesktop.Platform.Compat.i386
 ```
 
-Install Application
+####Install Application
 ```
 flatpak install flathub org.phoenicis.playonlinux
 ```


### PR DESCRIPTION
If you could get the flathub maintainers to add the additional 'Extension install command' before the 'Application Install command' ... it would help the users better, in fact the flathub application webpage is the right place for these instructions ... as not every user may find a need to visit the github page of the application.